### PR TITLE
Named modals

### DIFF
--- a/src/components/modal/profile/index.tsx
+++ b/src/components/modal/profile/index.tsx
@@ -9,6 +9,7 @@ import { Modal } from 'components/modal';
 import { AuthContext } from 'contexts/authContext';
 import { capitalizeString } from 'helpers/formatters';
 import { RoleDescription } from 'constants/roles';
+import { ModalNames } from 'constants/modals';
 
 export const ProfileModal = () => {
   const { closeModal, modalName } = useContext(InteractiveComponentsContext);
@@ -26,7 +27,7 @@ export const ProfileModal = () => {
   };
 
   return (
-    <Modal isModalOpened={modalName === 'profile-modal'} closeModal={closeModal}>
+    <Modal isModalOpened={modalName === ModalNames.PROFILE} closeModal={closeModal}>
       <Box
         sx={{
           position: 'absolute',

--- a/src/components/modal/profile/index.tsx
+++ b/src/components/modal/profile/index.tsx
@@ -11,7 +11,7 @@ import { capitalizeString } from 'helpers/formatters';
 import { RoleDescription } from 'constants/roles';
 
 export const ProfileModal = () => {
-  const { isModalOpened, closeModal } = useContext(InteractiveComponentsContext);
+  const { isModalOpened, closeModal, modalName } = useContext(InteractiveComponentsContext);
   const theme = useTheme();
   const { logoutUser, user } = useContext(AuthContext);
 
@@ -26,7 +26,7 @@ export const ProfileModal = () => {
   };
 
   return (
-    <Modal isModalOpened={isModalOpened} closeModal={closeModal}>
+    <Modal isModalOpened={isModalOpened && modalName === 'profile-modal'} closeModal={closeModal}>
       <Box
         sx={{
           position: 'absolute',

--- a/src/components/modal/profile/index.tsx
+++ b/src/components/modal/profile/index.tsx
@@ -11,7 +11,7 @@ import { capitalizeString } from 'helpers/formatters';
 import { RoleDescription } from 'constants/roles';
 
 export const ProfileModal = () => {
-  const { isModalOpened, closeModal, modalName } = useContext(InteractiveComponentsContext);
+  const { closeModal, modalName } = useContext(InteractiveComponentsContext);
   const theme = useTheme();
   const { logoutUser, user } = useContext(AuthContext);
 
@@ -26,7 +26,7 @@ export const ProfileModal = () => {
   };
 
   return (
-    <Modal isModalOpened={isModalOpened && modalName === 'profile-modal'} closeModal={closeModal}>
+    <Modal isModalOpened={modalName === 'profile-modal'} closeModal={closeModal}>
       <Box
         sx={{
           position: 'absolute',

--- a/src/components/topbar/index.tsx
+++ b/src/components/topbar/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/icons-material';
 import { ProfileModal } from 'components/modal/profile';
 import { InteractiveComponentsContext } from 'contexts/interactiveComponentsContext';
+import { ModalNames } from 'constants/modals';
 
 export default function TopBar() {
   const { openModal, toggleSidebar, isCollapsed } = useContext(InteractiveComponentsContext);
@@ -45,7 +46,7 @@ export default function TopBar() {
                     aria-haspopup='true'
                     color='inherit'
                     onClick={() => {
-                      openModal('profile-modal');
+                      openModal(ModalNames.PROFILE);
                     }}
                   >
                     <PersonIcon />

--- a/src/components/topbar/index.tsx
+++ b/src/components/topbar/index.tsx
@@ -44,7 +44,9 @@ export default function TopBar() {
                     aria-label='account of current user'
                     aria-haspopup='true'
                     color='inherit'
-                    onClick={openModal}
+                    onClick={() => {
+                      openModal('profile-modal');
+                    }}
                   >
                     <PersonIcon />
                   </IconButton>

--- a/src/constants/modals.ts
+++ b/src/constants/modals.ts
@@ -1,0 +1,4 @@
+export enum ModalNames {
+    PROFILE = 'profile-modal',
+    ASSIGN_RESP = 'assign-responsible-modal'
+}

--- a/src/contexts/interactiveComponentsContext.tsx
+++ b/src/contexts/interactiveComponentsContext.tsx
@@ -8,11 +8,8 @@ export interface InteractiveComponentsState {
   selectIndex: (index: string) => void;
   isModalOpened: boolean;
   closeModal: () => void;
-  openModal: () => void;
-  // assignResponsibleModal
-  isAssignResponsibleModalOpened: boolean,
-  openAssignResponsibleModal: () => void,
-  closeAssignResponsibleModal: () => void,
+  openModal: (modalName: string) => void;
+  modalName: string;
 }
 
 const InteractiveComponentsDefaultState: InteractiveComponentsState = {
@@ -23,10 +20,7 @@ const InteractiveComponentsDefaultState: InteractiveComponentsState = {
   isModalOpened: false,
   closeModal: () => null,
   openModal: () => null,
-  // assignResponsibleModal
-  isAssignResponsibleModalOpened: false,
-  openAssignResponsibleModal: () => { console.log('method not implemented') },
-  closeAssignResponsibleModal: () => { console.log('method not implemented') }
+  modalName: '',
 };
 
 export const InteractiveComponentsContext = createContext(InteractiveComponentsDefaultState);
@@ -37,7 +31,8 @@ export interface InteractiveComponentsProviderProps {
 export interface UseModalHook {
   isModalOpened: boolean;
   closeModal: () => void;
-  openModal: () => void;
+  openModal: (name: string) => void;
+  modalName: string;
   toggleModal: () => void;
 }
 
@@ -53,11 +48,18 @@ export interface UseIndexHook {
 
 const useModal: () => UseModalHook = () => {
   const [isModalOpened, setIsModalOpened] = useState(false);
-  const closeModal = () => setIsModalOpened(false);
-  const openModal = () => setIsModalOpened(true);
+  const [modalName, setModalName] = useState('');
+  const closeModal = () => {
+    setModalName('');
+    setIsModalOpened(false);
+  };
+  const openModal = (name: string) => {
+    setModalName(name);
+    setIsModalOpened(true);
+  };
   const toggleModal = () => setIsModalOpened(!isModalOpened);
 
-  return { isModalOpened, closeModal, openModal, toggleModal };
+  return { isModalOpened, closeModal, openModal, toggleModal, modalName };
 };
 
 const useSidebar: () => UseSidebarHook = () => {
@@ -81,12 +83,7 @@ export const InteractiveComponentsProvider: React.FC<InteractiveComponentsProvid
 }) => {
   const { selectedIndex, selectIndex } = useIndex();
   const { isCollapsed, toggleSidebar } = useSidebar();
-  const { isModalOpened, closeModal, openModal } = useModal();
-  const {
-    isModalOpened: isAssignResponsibleModalOpened,
-    openModal: openAssignResponsibleModal,
-    closeModal: closeAssignResponsibleModal
-  } = useModal();
+  const { isModalOpened, closeModal, openModal, modalName } = useModal();
 
   const state: InteractiveComponentsState = {
     isCollapsed,
@@ -96,11 +93,7 @@ export const InteractiveComponentsProvider: React.FC<InteractiveComponentsProvid
     isModalOpened,
     closeModal,
     openModal,
-
-    // assignResponsibleModal
-    isAssignResponsibleModalOpened,
-    openAssignResponsibleModal,
-    closeAssignResponsibleModal,
+    modalName,
   };
 
   return (

--- a/src/contexts/interactiveComponentsContext.tsx
+++ b/src/contexts/interactiveComponentsContext.tsx
@@ -6,7 +6,6 @@ export interface InteractiveComponentsState {
   toggleSidebar: () => void;
   selectedIndex: string;
   selectIndex: (index: string) => void;
-  isModalOpened: boolean;
   closeModal: () => void;
   openModal: (modalName: string) => void;
   modalName: string;
@@ -17,7 +16,6 @@ const InteractiveComponentsDefaultState: InteractiveComponentsState = {
   toggleSidebar: () => null,
   selectedIndex: '',
   selectIndex: () => null,
-  isModalOpened: false,
   closeModal: () => null,
   openModal: () => null,
   modalName: '',
@@ -29,11 +27,9 @@ export interface InteractiveComponentsProviderProps {
   children: JSX.Element;
 }
 export interface UseModalHook {
-  isModalOpened: boolean;
   closeModal: () => void;
   openModal: (name: string) => void;
   modalName: string;
-  toggleModal: () => void;
 }
 
 export interface UseSidebarHook {
@@ -47,19 +43,14 @@ export interface UseIndexHook {
 }
 
 const useModal: () => UseModalHook = () => {
-  const [isModalOpened, setIsModalOpened] = useState(false);
   const [modalName, setModalName] = useState('');
   const closeModal = () => {
     setModalName('');
-    setIsModalOpened(false);
   };
   const openModal = (name: string) => {
     setModalName(name);
-    setIsModalOpened(true);
   };
-  const toggleModal = () => setIsModalOpened(!isModalOpened);
-
-  return { isModalOpened, closeModal, openModal, toggleModal, modalName };
+  return { closeModal, openModal, modalName };
 };
 
 const useSidebar: () => UseSidebarHook = () => {
@@ -83,14 +74,13 @@ export const InteractiveComponentsProvider: React.FC<InteractiveComponentsProvid
 }) => {
   const { selectedIndex, selectIndex } = useIndex();
   const { isCollapsed, toggleSidebar } = useSidebar();
-  const { isModalOpened, closeModal, openModal, modalName } = useModal();
+  const { closeModal, openModal, modalName } = useModal();
 
   const state: InteractiveComponentsState = {
     isCollapsed,
     toggleSidebar,
     selectedIndex,
     selectIndex,
-    isModalOpened,
     closeModal,
     openModal,
     modalName,

--- a/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
+++ b/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
@@ -30,11 +30,7 @@ interface AssignResponsibleModalProps {
 const isInThePast = (date: Dayjs) => date.toDate() < new Date();
 
 export const AssignResponsibleModal = (props: AssignResponsibleModalProps) => {
-  const {
-    isAssignResponsibleModalOpened: isModalOpened,
-    closeAssignResponsibleModal: closeModal,
-  } = useContext(InteractiveComponentsContext);
-
+  const { isModalOpened, modalName, closeModal } = useContext(InteractiveComponentsContext);
 
   const {
     assignableResponsibles,
@@ -54,7 +50,7 @@ export const AssignResponsibleModal = (props: AssignResponsibleModalProps) => {
 
   return (
     <Modal
-      isModalOpened={isModalOpened}
+      isModalOpened={isModalOpened && modalName === 'assign-responsible-modal'}
       closeModal={closeModal}
     >
       <StyledModalCloseButton

--- a/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
+++ b/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
@@ -18,6 +18,7 @@ import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { UserDto } from "services/api/dtos";
 import { Dayjs } from "dayjs";
+import { ModalNames } from 'constants/modals';
 
 interface AssignResponsibleModalProps {
   assignableResponsibles: UserDto[];
@@ -50,7 +51,7 @@ export const AssignResponsibleModal = (props: AssignResponsibleModalProps) => {
 
   return (
     <Modal
-      isModalOpened={modalName === 'assign-responsible-modal'}
+      isModalOpened={modalName === ModalNames.ASSIGN_RESP}
       closeModal={closeModal}
     >
       <StyledModalCloseButton

--- a/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
+++ b/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
@@ -30,7 +30,7 @@ interface AssignResponsibleModalProps {
 const isInThePast = (date: Dayjs) => date.toDate() < new Date();
 
 export const AssignResponsibleModal = (props: AssignResponsibleModalProps) => {
-  const { isModalOpened, modalName, closeModal } = useContext(InteractiveComponentsContext);
+  const { modalName, closeModal } = useContext(InteractiveComponentsContext);
 
   const {
     assignableResponsibles,
@@ -50,7 +50,7 @@ export const AssignResponsibleModal = (props: AssignResponsibleModalProps) => {
 
   return (
     <Modal
-      isModalOpened={isModalOpened && modalName === 'assign-responsible-modal'}
+      isModalOpened={modalName === 'assign-responsible-modal'}
       closeModal={closeModal}
     >
       <StyledModalCloseButton

--- a/src/screens/documentDetails/components/content/index.tsx
+++ b/src/screens/documentDetails/components/content/index.tsx
@@ -9,6 +9,7 @@ import DocumentProcessedData from '../documentProcessedData';
 import DocumentAttachments from '../documentAttachments';
 import { InteractiveComponentsContext } from 'contexts/interactiveComponentsContext';
 import { useDocumentDetails } from 'screens/documentDetails/hooks/useDocumentDetails';
+import { ModalNames } from 'constants/modals';
 
 export default function DocumentDetailsContent() {
   const { assignableResponsibles } = useContext(DocumentDetailsContext);
@@ -46,9 +47,9 @@ export default function DocumentDetailsContent() {
       <Box sx={{ mb: 4 }}>
         <DocumentActivity
           document={document}
-          isModalOpened={modalName === 'assign-responsible-modal'}
+          isModalOpened={modalName === ModalNames.ASSIGN_RESP}
           openModal={() => {
-            openModal('assign-responsible-modal');
+            openModal(ModalNames.ASSIGN_RESP);
           }}
           assignableResponsibles={assignableResponsibles}
           assignResponsible={assignResponsible}

--- a/src/screens/documentDetails/components/content/index.tsx
+++ b/src/screens/documentDetails/components/content/index.tsx
@@ -13,7 +13,7 @@ import { useDocumentDetails } from 'screens/documentDetails/hooks/useDocumentDet
 export default function DocumentDetailsContent() {
   const { assignableResponsibles } = useContext(DocumentDetailsContext);
 
-  const { isModalOpened, openModal, modalName } = useContext(InteractiveComponentsContext);
+  const { openModal, modalName } = useContext(InteractiveComponentsContext);
 
   const { document, assignResponsible, setDeadline, uploadAttachment } = useDocumentDetails();
 
@@ -46,7 +46,7 @@ export default function DocumentDetailsContent() {
       <Box sx={{ mb: 4 }}>
         <DocumentActivity
           document={document}
-          isModalOpened={isModalOpened && modalName === 'assign-responsible-modal'}
+          isModalOpened={modalName === 'assign-responsible-modal'}
           openModal={() => {
             openModal('assign-responsible-modal');
           }}

--- a/src/screens/documentDetails/components/content/index.tsx
+++ b/src/screens/documentDetails/components/content/index.tsx
@@ -13,8 +13,7 @@ import { useDocumentDetails } from 'screens/documentDetails/hooks/useDocumentDet
 export default function DocumentDetailsContent() {
   const { assignableResponsibles } = useContext(DocumentDetailsContext);
 
-  const { isAssignResponsibleModalOpened: isModalOpened, openAssignResponsibleModal: openModal } =
-    useContext(InteractiveComponentsContext);
+  const { isModalOpened, openModal, modalName } = useContext(InteractiveComponentsContext);
 
   const { document, assignResponsible, setDeadline, uploadAttachment } = useDocumentDetails();
 
@@ -47,8 +46,10 @@ export default function DocumentDetailsContent() {
       <Box sx={{ mb: 4 }}>
         <DocumentActivity
           document={document}
-          isModalOpened={isModalOpened}
-          openModal={openModal}
+          isModalOpened={isModalOpened && modalName === 'assign-responsible-modal'}
+          openModal={() => {
+            openModal('assign-responsible-modal');
+          }}
           assignableResponsibles={assignableResponsibles}
           assignResponsible={assignResponsible}
           setDeadline={setDeadline}

--- a/src/screens/documentDetails/components/documentActivity/index.tsx
+++ b/src/screens/documentDetails/components/documentActivity/index.tsx
@@ -4,6 +4,7 @@ import { FormattedDate } from '../../../../components/formatedDate';
 import React from 'react';
 import { DocumentDto, UserDto } from '../../../../services/api/dtos';
 import { AssignResponsibleModal } from '../assignResponsibleModal';
+import { ModalNames } from 'constants/modals';
 
 interface DocumentActivityProps {
   document: DocumentDto;
@@ -60,7 +61,7 @@ function DocumentActivity(props: DocumentActivityProps) {
             <Button
               variant='contained'
               onClick={() => {
-                openModal('assign-responsible-modal');
+                openModal(ModalNames.ASSIGN_RESP);
               }}
             >
               Actualizeaza responsabil/termen

--- a/src/screens/documentDetails/components/documentActivity/index.tsx
+++ b/src/screens/documentDetails/components/documentActivity/index.tsx
@@ -11,18 +11,11 @@ interface DocumentActivityProps {
   assignableResponsibles: UserDto[];
   assignResponsible: (userId: string) => void;
   setDeadline: (date: string | undefined) => void;
-  openModal: () => void; 
+  openModal: (modalName: string) => void;
 }
 
 function DocumentActivity(props: DocumentActivityProps) {
-
-  const {
-    document,
-    openModal,
-    assignableResponsibles,
-    assignResponsible,
-    setDeadline
-  } = props;
+  const { document, openModal, assignableResponsibles, assignResponsible, setDeadline } = props;
 
   const assignedUser = document.assignedUser
     ? `${document.assignedUser.surname} ${document.assignedUser.name}`
@@ -66,7 +59,9 @@ function DocumentActivity(props: DocumentActivityProps) {
           <Stack gap={4}>
             <Button
               variant='contained'
-              onClick={openModal}
+              onClick={() => {
+                openModal('assign-responsible-modal');
+              }}
             >
               Actualizeaza responsabil/termen
             </Button>


### PR DESCRIPTION
- added `modalName` to the `InteractiveComponentsState` state
- added a `name` parameter to the `openModal` method so that now the modal will be opened by name
- clearing the `modalName` when closing the modal
- removed the `isModalOpened` boolean from the `InteractiveComponentsState` state since we only need the name of it to match when checking if its opened