### PR TITLE
several ui improvements

### DIFF
--- a/src/components/sidebar/sideMenuItems.ts
+++ b/src/components/sidebar/sideMenuItems.ts
@@ -42,7 +42,7 @@ export const menuItems: SubMenuProps[] = [
     items: [
       {
         icon: BuildIcon,
-        text: 'Optiuni',
+        text: 'Cuvinte cheie',
         href: Paths.OPTIONS,
       },
       {

--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -20,7 +20,7 @@ export const SIDEBAR_BUTTONS_LIST = [
     Icon: ScreenSearchDesktopOutlinedIcon,
   },
   {
-    key: 'Optiuni',
+    key: 'Cuvinte cheie',
     Icon: SettingsOutlinedIcon,
   },
   {

--- a/src/constants/translations.ts
+++ b/src/constants/translations.ts
@@ -13,7 +13,7 @@ export const Translations: Record<string, string> = {
     mae: 'Ministerul Afacerilor Externe',
     mai: 'Ministerul Afacerilor Interne',
     mapn: 'Ministerul Apararii Nationale',
-    DELETED: 'Sters',
+    DELETED: 'Dezactivat',
     ACTIVE: 'Activ',
     created: 'Creat',
     downloaded: 'Descarcat',

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -81,7 +81,6 @@
     "publishedBefore": "Publicat pana la:",
     "content": "Documentul contine textul...",
     "rulesBreaker": "Document ce contravine normelor in vigoare",
-    "important": "Proiect legislativ cu impact",
     "noResults": "Nu exista rezultate"
   },
   "projectView": {

--- a/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
+++ b/src/screens/documentDetails/components/assignResponsibleModal/index.tsx
@@ -145,9 +145,10 @@ export const AssignResponsibleModal = (props: AssignResponsibleModalProps) => {
                     onChange={(newDate: Dayjs | null) => field.onChange(newDate?.toString())}
                     componentsProps={{
                       actionBar: {
-                        actions: ['clear'],
+                        actions: ['cancel', 'accept'],
                       },
                     }}
+                    closeOnSelect={false}
                   />
                 </LocalizationProvider>
               )}

--- a/src/screens/documentDetails/components/documentGeneralData/index.tsx
+++ b/src/screens/documentDetails/components/documentGeneralData/index.tsx
@@ -9,6 +9,7 @@ import { SourceDescription } from 'constants/sources';
 import styled from 'styled-components';
 import config from '../../../../config/index';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 interface DocumentGeneralDataProps {
   document: DocumentDto;
@@ -53,12 +54,14 @@ function DocumentGeneralData({ document }: DocumentGeneralDataProps) {
                 <Typography variant='h5' sx={{ mb: 3 }}>
                   {document.title}
                 </Typography>
-                <Typography variant='h5' sx={{ mb: 3 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                    {document.project.title}
-                    <StarsIcon color='primary' fontSize='small' sx={{ ml: 2 }} />
-                  </Box>
-                </Typography>
+                <StyledLink target='_blank' to={`/project/${document.project?.id}`} rel='noreferrer'>
+                  <Typography variant='h5' sx={{ mb: 3 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                      {document.project.title}
+                      <StarsIcon color='primary' fontSize='small' sx={{ ml: 2 }} />
+                    </Box>
+                  </Typography>
+                </StyledLink>
                 <Typography variant='h5' sx={{ mb: 3 }}>
                   {document.identifier}
                 </Typography>
@@ -107,3 +110,14 @@ const LinkNoStyle = styled.a`
   text-decoration: none;
   color: inherit;
 `;
+
+const StyledLink = styled(Link)(({ theme }) => ({
+  textDecoration: 'none',
+  color: theme.palette.text.primary,
+  ['&:focus, &:visited, &:active, &:active']: {
+    color: theme.palette.text.primary,
+  },
+  ['&:hover']: {
+    color: theme.palette.text.secondary,
+  },
+}));

--- a/src/screens/documentSearch/components/searchForm/index.tsx
+++ b/src/screens/documentSearch/components/searchForm/index.tsx
@@ -244,9 +244,10 @@ export const SearchForm = (props: SearchFormProps) => {
                     onChange={(newDate: Dayjs | null) => field.onChange(newDate?.toString())}
                     componentsProps={{
                       actionBar: {
-                        actions: ['clear'],
+                        actions: ['clear', 'accept'],
                       },
                     }}
+                    closeOnSelect={false}
                   />
                 </LocalizationProvider>
               )}
@@ -267,9 +268,10 @@ export const SearchForm = (props: SearchFormProps) => {
                     onChange={(newDate: Dayjs | null) => field.onChange(newDate?.toString())}
                     componentsProps={{
                       actionBar: {
-                        actions: ['clear'],
+                        actions: ['clear', 'accept'],
                       },
                     }}
+                    closeOnSelect={false}
                   />
                 </LocalizationProvider>
               )}
@@ -307,13 +309,6 @@ export const SearchForm = (props: SearchFormProps) => {
                 />
               }
               label={t('documentSearch.rulesBreaker')}
-            />
-          </Grid>
-          <Grid item md={6} sx={{ pl: 4 }}>
-            <FormControlLabel
-              control={<Checkbox checked={false}/>}
-              label={t('documentSearch.important')}
-              disabled
             />
           </Grid>
         </Grid>

--- a/src/screens/projectsSearch/components/searchForm/index.tsx
+++ b/src/screens/projectsSearch/components/searchForm/index.tsx
@@ -113,9 +113,10 @@ export const SearchForm = (props: SearchFormProps) => {
                     onChange={(newDate: Dayjs | null) => field.onChange(newDate?.toString())}
                     componentsProps={{
                       actionBar: {
-                        actions: ['clear'],
+                        actions: ['clear', 'accept'],
                       },
                     }}
+                    closeOnSelect={false}
                   />
                 </LocalizationProvider>
               )}
@@ -136,9 +137,10 @@ export const SearchForm = (props: SearchFormProps) => {
                     onChange={(newDate: Dayjs | null) => field.onChange(newDate?.toString())}
                     componentsProps={{
                       actionBar: {
-                        actions: ['clear'],
+                        actions: ['clear', 'accept'],
                       },
                     }}
+                    closeOnSelect={false}
                   />
                 </LocalizationProvider>
               )}


### PR DESCRIPTION
- renamed the status from "sters" to "dezactivat" in the user list
- [keywords] changed the name from Options to "Cuvinte Cheie" in the sidebar
- [DOCUMENT SEARCH] - removed "proiect legsilativ cu impact"" checkbox
- all of the calendars are now having an ok button
- [Document view] the project name from the document view is now clickable and this takes the user to the project view